### PR TITLE
Corrige les alertes CodeQL d’exposition d’erreurs et vault

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -245,7 +245,7 @@ async def get_metrics(_: None = Depends(require_api_key)) -> Response:
         logger.exception("Erreur métriques")
         return JSONResponse(
             status_code=500,
-            content={"error": f"Erreur métriques : {e!s}"},
+            content={"error": "internal_error"},
         )
 
 

--- a/modules/cognitive_reactor/core.py
+++ b/modules/cognitive_reactor/core.py
@@ -58,10 +58,10 @@ async def get_metrics() -> PlainTextResponse | JSONResponse:
         cognitive_reactor_reactions.set(reactor.reaction_count)
         prometheus_data = generate_latest()
         return PlainTextResponse(content=prometheus_data, media_type=CONTENT_TYPE_LATEST)
-    except Exception as e:
+    except Exception:
         return JSONResponse(
             status_code=500,
-            content={"error": f"Erreur métriques : {str(e)}"},
+            content={"error": "internal_error"},
         )
 
 
@@ -69,8 +69,8 @@ async def get_metrics() -> PlainTextResponse | JSONResponse:
 async def health() -> dict[str, str]:
     try:
         return {"status": "ok", "service": "cognitive_reactor"}
-    except Exception as e:
-        return {"status": "unhealthy", "error": str(e)}
+    except Exception:
+        return {"status": "unhealthy", "error": "internal_error"}
 
 
 class CognitiveReactor:

--- a/modules/monitoring/prometheus_metrics.py
+++ b/modules/monitoring/prometheus_metrics.py
@@ -242,11 +242,11 @@ async def get_metrics() -> Response:
     try:
         prometheus_data = metrics.generate_metrics()
         return PlainTextResponse(content=prometheus_data, media_type=CONTENT_TYPE_LATEST)
-    except Exception as e:
-        ark_logger.error(f"Erreur endpoint métriques: {e}", extra={"arkalia_module": "monitoring"})
+    except Exception:
+        ark_logger.error("Erreur endpoint métriques", extra={"arkalia_module": "monitoring"})
         return JSONResponse(
             status_code=500,
-            content={"error": f"Erreur métriques : {str(e)}"},
+            content={"error": "internal_error"},
         )
 
 
@@ -256,12 +256,14 @@ async def health_check() -> Response:
     🏥 Endpoint de santé du monitoring
     """
     try:
-        return {
+        return JSONResponse(
+            content={
             "status": "healthy",
             "timestamp": datetime.now().isoformat(),
             "metrics_collected": True,
             "modules_monitored": 7,
-        }
-    except Exception as e:
-        ark_logger.error(f"Erreur health check: {e}", extra={"arkalia_module": "monitoring"})
-        return JSONResponse(status_code=500, content={"status": "unhealthy", "error": str(e)})
+            }
+        )
+    except Exception:
+        ark_logger.error("Erreur health check", extra={"arkalia_module": "monitoring"})
+        return JSONResponse(status_code=500, content={"status": "unhealthy", "error": "internal_error"})

--- a/modules/reflexia/core_api.py
+++ b/modules/reflexia/core_api.py
@@ -7,6 +7,7 @@ Ce module fait partie du système Arkalia Luna Pro.
 # 📁 modules/reflexia/core_api.py
 
 import os
+from typing import Any
 
 from fastapi import APIRouter, Depends, FastAPI, Header, HTTPException
 from fastapi.responses import JSONResponse, PlainTextResponse
@@ -50,7 +51,7 @@ def get_reflexia_status() -> dict:
 
 
 @router.get("/health", operation_id="reflexia_router_health")
-async def reflexia_health():
+async def reflexia_health() -> dict[str, str]:
     """
     Health check Reflexia sur le router monté sous /reflexia (API principale + CI).
 
@@ -59,12 +60,12 @@ async def reflexia_health():
     """
     try:
         return {"status": "ok", "service": "reflexia", "module": "reflexia"}
-    except Exception as e:
-        return {"status": "unhealthy", "error": str(e)}
+    except Exception:
+        return {"status": "unhealthy", "error": "internal_error"}
 
 
 @router.get("/check")
-async def check_reflexia_status(_: None = Depends(require_api_key)):
+async def check_reflexia_status(_: None = Depends(require_api_key)) -> JSONResponse:
     """
     Endpoint de vérification réflexive.
 
@@ -86,15 +87,15 @@ async def check_reflexia_status(_: None = Depends(require_api_key)):
     """
     try:
         return JSONResponse(content=get_reflexia_status())
-    except Exception as e:
+    except Exception:
         return JSONResponse(
             status_code=500,
-            content={"error": f"Erreur réflexive : {str(e)}"},
+            content={"error": "internal_error"},
         )
 
 
 @router.get("/metrics")
-async def get_metrics(_: None = Depends(require_api_key)):
+async def get_metrics(_: None = Depends(require_api_key)) -> PlainTextResponse | JSONResponse:
     """
     Endpoint métriques Prometheus pour Reflexia.
 
@@ -128,15 +129,15 @@ async def get_metrics(_: None = Depends(require_api_key)):
         prometheus_data = generate_latest()
 
         return PlainTextResponse(content=prometheus_data, media_type=CONTENT_TYPE_LATEST)
-    except Exception as e:
+    except Exception:
         return JSONResponse(
             status_code=500,
-            content={"error": f"Erreur métriques : {str(e)}"},
+            content={"error": "internal_error"},
         )
 
 
 @app.get("/health")
-async def health():
+async def health() -> dict[str, str]:
     """
     Health check pour le service Reflexia.
 
@@ -151,5 +152,5 @@ async def health():
     """
     try:
         return {"status": "ok", "service": "reflexia"}
-    except Exception as e:
-        return {"status": "unhealthy", "error": str(e)}
+    except Exception:
+        return {"status": "unhealthy", "error": "internal_error"}

--- a/modules/sandozia/core/sandozia_core.py
+++ b/modules/sandozia/core/sandozia_core.py
@@ -114,10 +114,10 @@ async def get_metrics() -> Any:
             sandozia_coherence_score.set(core.metrics_history[-1].coherence_score)
         prometheus_data = generate_latest()
         return PlainTextResponse(content=prometheus_data, media_type=CONTENT_TYPE_LATEST)
-    except Exception as e:
+    except Exception:
         return JSONResponse(
             status_code=500,
-            content={"error": f"Erreur métriques : {str(e)}"},
+            content={"error": "internal_error"},
         )
 
 

--- a/modules/security/crypto/vault_manager.py
+++ b/modules/security/crypto/vault_manager.py
@@ -9,6 +9,7 @@ Ce module fait partie du système Arkalia Luna Pro.
 
 import json
 import os
+import hashlib
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -174,8 +175,8 @@ class ArkaliaVault(BuildIntegrityValidator):
             secrets_dict: dict[str, str] = json.loads(decrypted_data.decode())
             return secrets_dict
         except Exception as e:
-            ark_logger.error(f"❌ Error loading secrets: {e}", extra={"arkalia_module": "security"})
-            raise VaultError(f"Failed to decrypt vault: {e}") from e
+            ark_logger.exception("❌ Error loading secrets", extra={"arkalia_module": "security"})
+            raise VaultError("Failed to decrypt vault") from e
 
     def _save_secrets(self, secrets: dict[str, str]) -> None:
         try:
@@ -184,12 +185,15 @@ class ArkaliaVault(BuildIntegrityValidator):
             self.secrets_file.write_bytes(encrypted_data)
             os.chmod(self.secrets_file, 0o600)
         except Exception as e:
-            ark_logger.error(f"❌ Error saving secrets: {e}", extra={"arkalia_module": "security"})
-            raise VaultError(f"Failed to encrypt vault: {e}") from e
+            ark_logger.exception("❌ Error saving secrets", extra={"arkalia_module": "security"})
+            raise VaultError("Failed to encrypt vault") from e
 
     def _audit_log_entry(self, action: str, secret_name: str, details: str = "") -> None:
         timestamp = datetime.now().isoformat()
-        log_entry = f"{timestamp} | {action} | {secret_name} | {details}\n"
+        # Avoid plaintext leakage of secret identifiers/details in audit logs.
+        secret_ref = hashlib.sha256(secret_name.encode("utf-8")).hexdigest()[:12]
+        details_ref = "redacted" if details else ""
+        log_entry = f"{timestamp} | {action} | secret_ref={secret_ref} | {details_ref}\n"
 
         self._trim_log_if_needed(self.audit_log, MAX_AUDIT_LOG_BYTES)
         with open(self.audit_log, "a") as f:
@@ -446,8 +450,8 @@ class ArkaliaVault(BuildIntegrityValidator):
                 self.key_file.write_bytes(backup_key_file.read_bytes())
                 self.cipher_suite = self._initialize_encryption()
 
-            ark_logger.error(f"❌ Key rotation failed: {e}", extra={"arkalia_module": "security"})
-            raise VaultError(f"Key rotation failed: {e}") from e
+            ark_logger.exception("❌ Key rotation failed", extra={"arkalia_module": "security"})
+            raise VaultError("Key rotation failed") from e
 
     def validate_vault_integrity(self) -> bool:
         """
@@ -468,7 +472,7 @@ class ArkaliaVault(BuildIntegrityValidator):
         try:
             super().validate_integrity()
         except SecurityError as e:
-            raise VaultError(f"Base integrity validation failed: {e}") from e
+            raise VaultError("Base integrity validation failed") from e
 
         # 2. Validation spécifique du vault
         violations: list[Any] = []
@@ -505,7 +509,7 @@ class ArkaliaVault(BuildIntegrityValidator):
         if violations:
             violation_msg = "; ".join(violations)
             self._audit_log_entry("INTEGRITY_VIOLATION", "SYSTEM", violation_msg)
-            raise VaultError(f"Vault integrity violations: {violation_msg}")
+            raise VaultError("Vault integrity violations detected")
 
         ark_logger.info(
             "✅ Vault integrity validation PASSED", extra={"arkalia_module": "security"}
@@ -578,13 +582,11 @@ class ArkaliaVault(BuildIntegrityValidator):
                 "last_check": datetime.now().isoformat(),
             }
 
-        except Exception as e:
-            ark_logger.error(
-                f"❌ Security health check failed: {e}", extra={"arkalia_module": "security"}
-            )
+        except Exception:
+            ark_logger.exception("❌ Security health check failed", extra={"arkalia_module": "security"})
             return {
                 "score": 0.0,
-                "error": str(e),
+                "error": "internal_error",
                 "secrets_count": 0,
                 "last_check": datetime.now().isoformat(),
             }
@@ -622,7 +624,7 @@ def migrate_from_env_file(
                 f"📦 .env backed up to: {backup_path}", extra={"arkalia_module": "security"}
             )
         except OSError as e:
-            raise VaultError(f"Failed to backup env file '{env_path}': {e}") from e
+            raise VaultError(f"Failed to backup env file '{env_path}'") from e
 
     # Parser le fichier .env
     secrets_migrated = 0
@@ -658,7 +660,7 @@ def migrate_from_env_file(
                             extra={"arkalia_module": "security"},
                         )
     except OSError as e:
-        raise VaultError(f"Failed to read env file '{env_path}': {e}") from e
+        raise VaultError(f"Failed to read env file '{env_path}'") from e
 
     ark_logger.info(
         f"🚀 Migration completed: {secrets_migrated} secrets migrated from {env_path}",


### PR DESCRIPTION
## Summary
- remplace les retours d'erreur détaillés par `internal_error` sur les endpoints exposés
- durcit `vault_manager` pour éviter les fuites (messages d'exception et audit log redacted)
- conserve les logs internes sans exposer les détails côté API

## Test plan
- [x] ReadLints sur les fichiers modifiés
- [x] push sur `develop`
- [ ] merger cette PR pour aligner `main`


Made with [Cursor](https://cursor.com)