### PR TITLE
Évite l'annulation automatique des runs Deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   # 🔍 Validation pré-déploiement


### PR DESCRIPTION
## Summary
- désactive `cancel-in-progress` dans la concurrence du workflow `Deploy · App`
- évite le message "Canceling since a higher priority waiting request exists" sur `develop`

## Test plan
- [x] validation YAML locale
- [x] push sur `develop`
- [ ] merge vers `main`

Made with [Cursor](https://cursor.com)