### PR TITLE
Gitleaks: allowlist doc/tests + allègement secret-scan

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -10,8 +10,6 @@ on:
   workflow_dispatch:
 
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 permissions:
   contents: read
   security-events: write

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,34 @@
+# Configuration Gitleaks : réduit les faux positifs (docs, tests, démos) tout en
+# conservant la détection sur le code applicatif (app/, modules/, etc.).
+
+title = "arkalia-luna-pro"
+
+[extend]
+# Règles par défaut (dépend de la version embarquée par l’action Gitleaks)
+useDefault = true
+
+# Chemins fréquemment utilisés pour des exemples, de la doc et des tests.
+# Les vrais secrets doivent rester hors de ces répertoires ou dans le gestionnaire de secrets.
+[allowlist]
+description = "Documentation, tests, assets générés, démos explicites"
+paths = [
+  '''^docs/''',
+  '''^tests/''',
+  '''^test/''',
+  '''^e2e/''',
+  '''^examples/''',
+  '''^spec/''',
+  '''^site/''',
+  '''^\.github/''',
+  '''^scripts/demo_arkalia_vault\.py$''',
+  '''^scripts/ark-secret-check\.sh$''',
+  '''^docs/api\.md$''',
+]
+
+# Placeholders et textes d’exemple courants (alignés avec la doc API).
+regexes = [
+  '''<redacted[^>]*>''',
+  '''<api[_-]?key>''',
+  '''REDACTED''',
+  '''example[_-]?key''',
+]


### PR DESCRIPTION
## Summary
- ajoute `.gitleaks.toml` pour réduire les faux positifs (doc, tests, scripts de démo)
- retire `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` du workflow secret-scan

## Test plan
- le prochain run planifié **Security · Secret Scan** sur `main` doit passer

Made with [Cursor](https://cursor.com)