### PR TITLE
Gitleaks: allowlist .secrets.baseline

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -23,6 +23,8 @@ paths = [
   '''^scripts/demo_arkalia_vault\.py$''',
   '''^scripts/ark-secret-check\.sh$''',
   '''^docs/api\.md$''',
+  # Baseline detect-secrets : contient des hash / entrées volontairement listées.
+  '''(^|/)\.secrets\.baseline$''',
 ]
 
 # Placeholders et textes d’exemple courants (alignés avec la doc API).


### PR DESCRIPTION
Évite les alertes sur le fichier baseline officiel de detect-secrets.

Made with [Cursor](https://cursor.com)