### PR TITLE
Gitleaks: .gitleaksignore + --config explicite pour .secrets.baseline

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -30,5 +30,10 @@ jobs:
 
       - name: Run Gitleaks
         uses: gitleaks/gitleaks-action@v2
+        with:
+          # Force la config repo ; .gitleaksignore est lu automatiquement au même niveau.
+          args: "--config .gitleaks.toml --verbose"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Évite l’avertissement Node 20 jusqu’à mise à jour de gitleaks-action.
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -23,8 +23,9 @@ paths = [
   '''^scripts/demo_arkalia_vault\.py$''',
   '''^scripts/ark-secret-check\.sh$''',
   '''^docs/api\.md$''',
-  # Baseline detect-secrets : contient des hash / entrées volontairement listées.
-  '''(^|/)\.secrets\.baseline$''',
+  # Baseline detect-secrets (voir aussi .gitleaksignore).
+  '''\.secrets\.baseline$''',
+  '''[/\\]\.secrets\.baseline$''',
 ]
 
 # Placeholders et textes d’exemple courants (alignés avec la doc API).

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,3 @@
+# Fichiers exclus du scan (chemins relatifs à la racine du dépôt).
+# Baseline detect-secrets : hashes / métadonnées, pas des secrets en clair exploitables.
+.secrets.baseline


### PR DESCRIPTION
## Summary
- ajoute `.gitleaksignore` pour exclure `.secrets.baseline` (baseline detect-secrets)
- passe `--config .gitleaks.toml` explicitement à gitleaks-action
- complète les motifs allowlist ; réactive `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` pour réduire l’avertissement Node 20

## Test plan
- workflow Security · Secret Scan sur `main` au vert

Made with [Cursor](https://cursor.com)