### PR TITLE
Secret Scan : sans concurrency pour éviter les annulations

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -14,9 +14,8 @@ permissions:
   contents: read
   security-events: write
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+# Pas de groupe concurrency : évite les annulations « higher priority waiting request »
+# sur develop quand push + PR + schedule se chevauchent.
 
 jobs:
   gitleaks:


### PR DESCRIPTION
Supprime le groupe concurrency afin d'éliminer les messages d'annulation liés aux requêtes prioritaires sur la même branche.

Made with [Cursor](https://cursor.com)