### PR TITLE
Secret scan : GITLEAKS_CONFIG + allowlist (MkDocs search)

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -29,10 +29,11 @@ jobs:
 
       - name: Run Gitleaks
         uses: gitleaks/gitleaks-action@v2
-        with:
-          # Force la config repo ; .gitleaksignore est lu automatiquement au même niveau.
-          args: "--config .gitleaks.toml --verbose"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # L’action n’accepte pas `with: args` : la CLI est invoquée avec des flags fixes.
+          # Sans cette variable, seule la config par défaut s’applique → faux positifs massifs
+          # sur `.secrets.baseline` et autres chemins listés dans `.gitleaks.toml`.
+          GITLEAKS_CONFIG: ${{ github.workspace }}/.gitleaks.toml
           # Évite l’avertissement Node 20 jusqu’à mise à jour de gitleaks-action.
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -19,13 +19,13 @@ paths = [
   '''^examples/''',
   '''^spec/''',
   '''^site/''',
+  '''^search/search_index\.json$''',
   '''^\.github/''',
   '''^scripts/demo_arkalia_vault\.py$''',
   '''^scripts/ark-secret-check\.sh$''',
   '''^docs/api\.md$''',
-  # Baseline detect-secrets (voir aussi .gitleaksignore).
-  '''\.secrets\.baseline$''',
-  '''[/\\]\.secrets\.baseline$''',
+  # Baseline detect-secrets : empreintes / métadonnées, pas des secrets exploitables.
+  '''(^|[/\\])\.secrets\.baseline$''',
 ]
 
 # Placeholders et textes d’exemple courants (alignés avec la doc API).

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,3 +1,3 @@
-# Fichiers exclus du scan (chemins relatifs à la racine du dépôt).
-# Baseline detect-secrets : hashes / métadonnées, pas des secrets en clair exploitables.
-.secrets.baseline
+# Ignorer des fuites précises via leur champ `Fingerprint` dans un rapport JSON Gitleaks.
+# Ce fichier n’accepte pas des chemins de fichiers ; pour exclure tout un fichier,
+# utiliser `[allowlist] paths` dans `.gitleaks.toml`.


### PR DESCRIPTION
## Summary
- charge `.gitleaks.toml` via `GITLEAKS_CONFIG` (compatible avec gitleaks-action)
- allowlist `search/search_index.json` ; motif `.secrets.baseline` clarifié
- documente le rôle de `.gitleaksignore` vs allowlist


Made with [Cursor](https://cursor.com)