### PR TITLE
Corrige stubPath Pylance (dossier typings)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -262,3 +262,8 @@ exclude = [
     "htmlcov",
     "benchmark_results"
 ]
+
+[tool.pyright]
+pythonVersion = "3.10"
+stubPath = "typings"
+reportMissingTypeStubs = false


### PR DESCRIPTION
## Summary
- ajoute le dossier `typings/` attendu par Pylance / Cursor Pyright
- déclare `stubPath` dans `[tool.pyright]` pour supprimer l’erreur de chemin invalide


Made with [Cursor](https://cursor.com)