### PR TITLE
ci: Node 24 artefacts et await ZeroIA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ on:
 
 env:
   PYTHON_VERSION: "3.10"
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   COVERAGE_MIN: 15
   SECURITY_COVERAGE_MIN: 10
   PERFORMANCE_COVERAGE_MIN: 10
@@ -109,7 +108,7 @@ jobs:
           fi
 
       - name: 📋 Upload enhanced linting artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: enhanced-linting-artifacts
@@ -214,7 +213,7 @@ jobs:
           verbose: true
 
       - name: 📋 Upload enhanced test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: enhanced-test-results-${{ matrix.os }}-${{ matrix.python-version }}
@@ -267,7 +266,7 @@ jobs:
           safety check --json --output safety-report.json || echo "⚠️ Safety check terminé avec avertissements"
 
       - name: 📋 Upload security report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: security-report
@@ -305,7 +304,7 @@ jobs:
           pytest tests/chaos/ --timeout=900 --no-cov -m "not slow" -v
 
       - name: 📋 Upload chaos artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: chaos-results
@@ -327,7 +326,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: 📋 Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         continue-on-error: true
         with:
           path: artifacts/
@@ -354,7 +353,7 @@ jobs:
           } > report.md
 
       - name: 📋 Upload final report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         continue-on-error: true
         timeout-minutes: 5
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,8 +9,6 @@ on:
     - cron: "15 3 * * 1"
 
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 permissions:
   actions: read
   contents: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,6 @@ on:
 
 env:
   PYTHON_VERSION: "3.10"
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   DOCKER_REGISTRY: "ghcr.io"
   DOCKER_BUILDKIT: 1
   COMPOSE_DOCKER_CLI_BUILD: 1
@@ -151,7 +150,7 @@ jobs:
 
       - name: 🐳 Build and push ${{ matrix.image }}
         if: steps.check-dockerfile.outputs.skip_build != 'true'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./${{ matrix.dockerfile }}
@@ -354,7 +353,7 @@ jobs:
           echo "- Gestion d'erreurs renforcée" >> deployment-report.md
 
       - name: 📋 Upload deployment report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         continue-on-error: true
         timeout-minutes: 5
         with:

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -35,5 +35,3 @@ jobs:
           # Sans cette variable, seule la config par défaut s’applique → faux positifs massifs
           # sur `.secrets.baseline` et autres chemins listés dans `.gitleaks.toml`.
           GITLEAKS_CONFIG: ${{ github.workspace }}/.gitleaks.toml
-          # Évite l’avertissement Node 20 jusqu’à mise à jour de gitleaks-action.
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -18,7 +18,6 @@ permissions:
 
 env:
   PYTHON_VERSION: "3.10"
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   SECURITY_SCAN_TIMEOUT: 600
 
 concurrency:
@@ -89,7 +88,7 @@ jobs:
           grep -r "USER" . --include="Dockerfile*" || echo "⚠️ Some Dockerfiles might not use non-root users"
 
       - name: 📊 Upload Security Reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         continue-on-error: true
         timeout-minutes: 5
         with:
@@ -183,7 +182,7 @@ jobs:
           cat npm-outdated.json || echo "No updates available"
 
       - name: 📊 Upload Dependency Reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         continue-on-error: true
         timeout-minutes: 5
         with:

--- a/tests/performance/integration/test_integration_performance.py
+++ b/tests/performance/integration/test_integration_performance.py
@@ -212,7 +212,7 @@ class TestIntegrationPerformance:
                 "cpu_usage": 60.0 + (operation_id % 20),
                 "memory_usage": 70.0 + (operation_id % 15),
             }
-            return zeroia_core.make_decision(context)
+            return await zeroia_core.make_decision(context)
 
         async def reflexia_operation(operation_id: int) -> Any:
             return reflexia_core.check_module_health(f"module_{operation_id % 3}")


### PR DESCRIPTION
## Summary
- Passe `actions/upload-artifact` et `download-artifact` de v4 (Node 20) à v7 (Node 24), et `docker/build-push-action` de v5 à v7.
- Retire `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`, devenu inutile.
- Corrige `ZeroIACoordinator.make_decision` non `await` dans le test de perf concurrent.

## Test plan
- [ ] CI · Build & Test vert (plus de warning `upload-artifact@v4` / Node 20)
- [ ] Deploy · App vert (build-push-action v7)
- [ ] Secret Scan / CodeQL verts
- [ ] Merger sur `develop` puis fast-forward `main`


Made with [Cursor](https://cursor.com)