### PR TITLE
fix: stubPath Pyright vide (erreur typings T7)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -265,5 +265,5 @@ exclude = [
 
 [tool.pyright]
 pythonVersion = "3.10"
-stubPath = "typings"
+stubPath = ""
 reportMissingTypeStubs = false


### PR DESCRIPTION
## Summary
- Cursor Pyright refuse `typings/` sur le volume T7 (`stubPath file:///… is not a valid directory`) même si le dossier existe.
- `stubPath` est mis à `""` : pas de stubs locaux, plus d’avertissement.

## Test plan
- [ ] Recharger la fenêtre Cursor
- [ ] L’avertissement stubPath a disparu


Made with [Cursor](https://cursor.com)